### PR TITLE
Configuration of file group after copy

### DIFF
--- a/axel.conf.sample
+++ b/axel.conf.sample
@@ -10,6 +10,8 @@ PushbulletChannel=
 MovieDirectory=
 # Required
 TVDirectory=
+# Group to chown files to
+Group=
 
 [CouchPotato]
 Category=couchpotato

--- a/axel/__init__.py
+++ b/axel/__init__.py
@@ -27,6 +27,9 @@ config['tv_dir'] = parser.get(
 config['tmdb_api_key'] = parser.get(
     'General', 'TheMovieDBAPIKey', fallback=''
 )
+config['group'] = parser.get(
+    'General', 'Group', fallback='plex'
+)
 
 config['transmission'] = {}
 config['transmission']['host'] = parser.get(

--- a/axel/core.py
+++ b/axel/core.py
@@ -32,6 +32,8 @@ sonarr_category = config['sonarr']['category']
 ignore_sonarr = config['sonarr']['ignore']
 drone_factory = config['sonarr']['drone_factory']
 
+plex_group = config['group']
+
 
 def whitelisted(torrent):
     return any(
@@ -202,7 +204,7 @@ def handle_sonarr(torrent):
                 if paths:
                     # Move extracted files to sonarr drone factory
                     for path in paths:
-                        shutil.chown(path, group='plex')
+                        shutil.chown(path, group=plex_group)
                         os.chmod(path, 0o664)
                         shutil.move(path, drone_factory)
 


### PR DESCRIPTION
Add the group to chown as to the config for installations that do not
use a group called 'plex'
